### PR TITLE
refactor: Clean up opcode usage and introduce op 8 error

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -97,14 +97,15 @@ encoding is assumed.
 
 | opcode | name            | mode | description |
 |--------|-----------------|------|-------------|
-| 0      | `hello`         | recv | Sent on initial connection to the gateway |
-| 1      | `identify`      | send | Tell the gateway who you are |
-| 2      | `ready`         | recv | The gateway has accepted you, and will send you packets |
-| 3      | `invalid`       | recv | The gateway doesn't like you for some reason, and wants you to go away (more info will be included in the `error` field of `d`) |
-| 4      | `dispatch`      | both | The gateway is sending you an event, or you are sending the gateway an event |
-| 5      | `heartbeat`     | send | Send a heartbeat to the gateway |
-| 6      | `heartbeat_ack` | recv | Gateway acknowledging the last heartbeat you sent |
-| 7      | `goodbye`       | recv | Sent to tell you to heck off and try reconnecting. Used for eg. load balancing. |
+| 0      | `hello`         | recv | Sent on initial connection to the server. |
+| 1      | `identify`      | send | Tell the server who you are. |
+| 2      | `ready`         | recv | The server has accepted you, and will send you packets |
+| 3      | `invalid`       | recv | Sent to tell you that an application-level issue with your payload occurred. |
+| 4      | `dispatch`      | both | The server is sending you an event, or you are sending the gateway an event. |
+| 5      | `heartbeat`     | send | Send a heartbeat to the server. |
+| 6      | `heartbeat_ack` | recv | Server acknowledging the last heartbeat you sent. |
+| 7      | `goodbye`       | recv | Sent to tell you to reconnect. Used for eg. load balancing. |
+| 8      | `error`         | recv | Sent to tell you that an unrecoverable error occurred. |
 
 ## 신경 events, the right way
 

--- a/lib/singyeong/gateway/dispatch.ex
+++ b/lib/singyeong/gateway/dispatch.ex
@@ -55,7 +55,7 @@ defmodule Singyeong.Gateway.Dispatch do
         {:ok, []}
 
       {:error, errors} ->
-        {:error, Payload.close_with_error("invalid metadata", errors)}
+        {:error, Payload.error("invalid metadata", errors)}
     end
   end
 
@@ -108,7 +108,7 @@ defmodule Singyeong.Gateway.Dispatch do
         {:ok, []}
 
       {:error, value} ->
-        {:error, Payload.close_with_error("Unroutable payload: #{value}", payload)}
+        {:error, Payload.error("Unroutable payload: #{value}", payload)}
     end
   end
 
@@ -118,7 +118,7 @@ defmodule Singyeong.Gateway.Dispatch do
         {:ok, []}
 
       {:error, value} ->
-        {:error, Payload.close_with_error("Unroutable payload: #{value}", payload)}
+        {:error, Payload.error("Unroutable payload: #{value}", payload)}
     end
   end
 
@@ -126,7 +126,7 @@ defmodule Singyeong.Gateway.Dispatch do
     plugins = PluginManager.plugins_for_event :custom_events, t
     case plugins do
       [] ->
-        {:error, Payload.close_with_error("invalid dispatch payload", payload)}
+        {:error, Payload.error("invalid dispatch payload", payload)}
 
       plugins when is_list(plugins) ->
         case run_pipeline(plugins, t, data, [], []) do
@@ -149,7 +149,7 @@ defmodule Singyeong.Gateway.Dispatch do
                 undo_errors: Enum.map(undo_errors, fn {:error, msg} -> msg end)
               }
 
-            {:error, Payload.close_with_error("Error processing plugin event #{t}", error_info)}
+            {:error, Payload.error("Error processing plugin event #{t}", error_info)}
         end
     end
   end

--- a/lib/singyeong/gateway/payload.ex
+++ b/lib/singyeong/gateway/payload.ex
@@ -119,12 +119,16 @@ defmodule Singyeong.Gateway.Payload do
     raise ArgumentError, "bad payload (op_atom = #{op_atom}, op_int = #{op_int}, t_bin = #{t_bin}, t_nil = #{t_nil}, d_map = #{d_map})"
   end
 
+  def error(err, extra_info \\ nil) do
+    create_payload :invalid, %Error{error: err, extra_info: extra_info}
+  end
+
   def close_with_payload(op, data) do
     {:close, create_payload(op, data)}
   end
 
   def close_with_error(err, extra_info \\ nil) do
-    close_with_op_and_error :invalid, err, extra_info
+    close_with_op_and_error :error, err, extra_info
   end
 
   def close_with_op_and_error(op, err, extra_info \\ nil) do

--- a/test/singyeong/plugin/dispatch_test.exs
+++ b/test/singyeong/plugin/dispatch_test.exs
@@ -87,7 +87,7 @@ defmodule Singyeong.Plugin.DispatchTest do
       }
 
     {:error, frames} = Dispatch.handle_dispatch socket, dispatch
-    {:close, {:text, %Payload{t: t, op: op, ts: ts, d: d}}} = frames
+    {:text, %Payload{t: t, op: op, ts: ts, d: d}} = frames
     assert Gateway.opcodes_name()[:invalid] == op
     assert nil == t
     %Error{
@@ -119,7 +119,7 @@ defmodule Singyeong.Plugin.DispatchTest do
       }
 
     {:error, frames} = Dispatch.handle_dispatch socket, dispatch
-    {:close, {:text, %Payload{t: t, op: op, ts: ts, d: d}}} = frames
+    {:text, %Payload{t: t, op: op, ts: ts, d: d}} = frames
     assert Gateway.opcodes_name()[:invalid] == op
     assert nil == t
     %Error{
@@ -151,7 +151,7 @@ defmodule Singyeong.Plugin.DispatchTest do
       }
 
     {:error, frames} = Dispatch.handle_dispatch socket, dispatch
-    {:close, {:text, %Payload{t: t, op: op, ts: ts, d: d}}} = frames
+    {:text, %Payload{t: t, op: op, ts: ts, d: d}} = frames
     assert Gateway.opcodes_name()[:invalid] == op
     assert nil == t
     %Error{


### PR DESCRIPTION
Closes #143.

- Adds a new opcode, `:error` (op 8), that is used to indicate an unrecoverable protocol-level error.
- No longer closes on `:invalid` packets.
- Continues only sending `:goodbye` for load-balancing purposes. 