### PR TITLE
fix: send a single payload on no_route error

### DIFF
--- a/lib/singyeong/gateway/dispatch.ex
+++ b/lib/singyeong/gateway/dispatch.ex
@@ -114,7 +114,7 @@ defmodule Singyeong.Gateway.Dispatch do
         {:ok, []}
 
       {:error, value} ->
-        {:error, Payload.error("Unroutable payload: #{value}", payload)}
+        {:error, Payload.error(value, Payload.to_outgoing(payload))}
     end
   end
 
@@ -124,7 +124,7 @@ defmodule Singyeong.Gateway.Dispatch do
         {:ok, []}
 
       {:error, value} ->
-        {:error, Payload.error("Unroutable payload: #{value}", payload)}
+        {:error, Payload.error(value, Payload.to_outgoing(payload))}
     end
   end
 

--- a/lib/singyeong/gateway/payload.ex
+++ b/lib/singyeong/gateway/payload.ex
@@ -168,4 +168,17 @@ defmodule Singyeong.Gateway.Payload do
   def close_with_op_and_error(op, err, extra_info \\ nil) do
     {:close, create_payload(op, %Error{error: err, extra_info: extra_info})}
   end
+
+  def to_outgoing(%__MODULE__{op: op, d: data, t: t, ts: ts}) when is_atom(op) do
+    %__MODULE__{
+      op: Gateway.opcodes_name()[op],
+      d: data,
+      t: t,
+      ts: ts,
+    }
+  end
+
+  def to_outgoing(%__MODULE__{} = payload) do
+    payload
+  end
 end

--- a/lib/singyeong/message_dispatcher.ex
+++ b/lib/singyeong/message_dispatcher.ex
@@ -30,18 +30,7 @@ defmodule Singyeong.MessageDispatcher do
   end
 
   def send_message(socket, _, 0, %Payload.Dispatch{target: %Query{droppable: false} = target, nonce: nonce}, _, nil) do
-    # No matches and not droppable, reply to initiator if possible
-    if socket != nil and is_pid(socket.transport_pid) and Process.alive?(socket.transport_pid) do
-      failure =
-        Payload.create_payload :invalid, %{
-          "error" => "no nodes match query for query #{inspect target, pretty: true}",
-          "d" => %{
-            "nonce" => nonce
-          }
-        }
-
-      send socket.transport_pid, failure
-    end
+    # No matches and not droppable, drop with an error
     {:error, :no_route}
   end
 


### PR DESCRIPTION
sg would broadcast 2 messages upon unroutable non-droppable requests. Removed the one in `message_dispatcher.ex` in favor of the more helpful payload sent by `dispatch.ex`.

Made it convert the opcode back to an integer, so the `extra_data` and be considered a copy of the sent payload rather than a plain dump of the internal object.

I also dropped the "Unroutable payload: " prefix, as it makes it harder to programatically analyze the `error` field, and know what's the actual problem, allowing to react accordingly