### PR TITLE
fix: remove some deprecated stuff

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,9 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
+# and its dependencies with the aid of the Config module.
 #
 # This configuration file is loaded before any dependency and
 # is restricted to this project.
-use Mix.Config
+import Config
 require Logger
 
 ################################################################
@@ -20,7 +20,7 @@ config :singyeong, SingyeongWeb.Endpoint,
 
 # Configures Elixir's Logger
 config :logger, :console,
-  format: "[$time] $metadata[$level]$levelpad $message\n",
+  format: "[$time] $metadata[$level] $message\n",
   metadata: [:file, :line]
 
 config :phoenix, :format_encoders,
@@ -52,7 +52,7 @@ gossip_topology =
 
 # Erlang distribution cookie
 cookie =
-  if Mix.env() == :prod do
+  if config_env() == :prod do
     System.get_env("COOKIE") || raise """
       \n
       ### ERROR ###
@@ -134,7 +134,7 @@ config :singyeong_plugin,
   # from whatever data is available.
   payload_module: Singyeong.Gateway.Payload
 
-import_config "#{Mix.env}.exs"
+import_config "#{config_env()}.exs"
 
 # Import custom configs. This should override EVERYTHING else, and so it must
 # stay at the very bottom.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # For production, we often load configuration from external
 # sources, such as your system environment. For this reason,

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :singyeong, SingyeongWeb.Endpoint,
   http: [port: 4001],

--- a/lib/singyeong/gateway/handler/conn_state.ex
+++ b/lib/singyeong/gateway/handler/conn_state.ex
@@ -3,7 +3,7 @@ defmodule Singyeong.Gateway.Handler.ConnState do
   alias Singyeong.Metadata.Query
 
   def send_update(app, mode) do
-    Dispatch.send_to_clients nil, %Payload.Dispatch{
+    Dispatch.send_to_clients %Payload.Dispatch{
         target: %Query{
           ops: [
             {:boolean, :op_eq, "/receive_client_updates", {:value, true}},

--- a/lib/singyeong/message_dispatcher.ex
+++ b/lib/singyeong/message_dispatcher.ex
@@ -11,7 +11,6 @@ defmodule Singyeong.MessageDispatcher do
   require Logger
 
   @spec send_message(
-        Plug.Socket.t() | nil, # Intiating socket
         [{node(), [Client.t()]}], # List of clients
         non_neg_integer(), # Number of clients
         Payload.Dispatch.t(), # Payload to send
@@ -21,20 +20,14 @@ defmodule Singyeong.MessageDispatcher do
       :: {:ok, :dropped}
          | {:ok, :sent}
          | {:error, :no_route}
+  def send_message(clients, client_count, dispatch, broadcast?, event_type \\ nil)
 
-  def send_message(socket, clients, client_count, dispatch, broadcast?, event_type \\ nil)
-
-  def send_message(_, _, 0, %Payload.Dispatch{target: %Query{droppable: true}}, _, nil) do
+  def send_message(_, 0, %Payload.Dispatch{target: %Query{droppable: true}}, _, nil) do
     # No matches and droppable, silently drop
     {:ok, :dropped}
   end
 
-  def send_message(socket, _, 0, %Payload.Dispatch{target: %Query{droppable: false} = target, nonce: nonce}, _, nil) do
-    # No matches and not droppable, drop with an error
-    {:error, :no_route}
-  end
-
-  def send_message(_socket, [_ | _] = clients, client_count, %Payload.Dispatch{
+  def send_message([_ | _] = clients, client_count, %Payload.Dispatch{
     nonce: nonce,
     payload: payload,
   }, broadcast?, type) when client_count > 0 do
@@ -64,7 +57,7 @@ defmodule Singyeong.MessageDispatcher do
     {:ok, :sent}
   end
 
-  def send_message(_, _, 0, _, _, _) do
+  def send_message(_, 0, _, _, _) do
     {:error, :no_route}
   end
 end


### PR DESCRIPTION
I hate it when software yells at me with yellow stuff >:D

MessageDispatcher.send_message and Dispatch.send_to_clients no longer take the sender as an arg as it's gone unused; removed redundant signature for queries that cannot be routed. (it seems it was a hacky thing anyways, as it was `nil` more often than a socket 🙄)

~~hopefully I didn't screw up this time and the build will work ugh~~